### PR TITLE
[FOR REFERENCE] Fix for optional strings when matching UTF8 messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivescript",
-  "version": "1.17.9",
+  "version": "1.17.10",
   "description": "RiveScript is a scripting language for chatterbots, making it easy to write trigger/response pairs for building up a bot's intelligence.",
   "keywords": [
     "bot",

--- a/src/brain.coffee
+++ b/src/brain.coffee
@@ -932,7 +932,20 @@ class Brain
       parts = match[1].split("|")
       opts  = []
       for p in parts
-        opts.push "(?:\\s|\\b)+#{p}(?:\\s|\\b)+"
+        p = parts[j]
+        # Word boundaries fail on UTF8 strings, so we shouldn't rely on them.
+        # If we start or end our regex with a boundary expectation ([\b]+), it
+        #   will always fail when a UTF8 string exists on that boundary.
+        # Therefore we want to make sure to skip such boundary checks at the ends of
+        # our regex, and we'll rely on the full-line checks added elsewhere in the code
+        # (^~this~$) to enforce boundaries.
+        # Note that this isn't perfect, still, as we still have to rely on spaces as word
+        # separators in UTF8 strings - unspaced comma separations would fail (foo,bar vs foo bar)
+        if match.index != 0 or j > 0
+            p = "(?:\\s|\\b)+" + p
+        if (match.index + 9) < regexp.length or j < len - 1
+            p += "(?:\\s|\\b)+"
+        opts.push(p)
 
       # If this optional had a star or anything in it, make it non-matching.
       pipes = opts.join("|")

--- a/src/brain.coffee
+++ b/src/brain.coffee
@@ -932,7 +932,7 @@ class Brain
 
       parts = match[1].split("|")
       opts  = []
-      for p, pidx in parts
+      for p in parts
         opts.push(boundary + p + boundary);
 
       # If this optional had a star or anything in it, make it non-matching.

--- a/src/brain.coffee
+++ b/src/brain.coffee
@@ -931,8 +931,7 @@ class Brain
 
       parts = match[1].split("|")
       opts  = []
-      for p in parts
-        p = parts[j]
+      for p, pidx in parts
         # Word boundaries fail on UTF8 strings, so we shouldn't rely on them.
         # If we start or end our regex with a boundary expectation ([\b]+), it
         #   will always fail when a UTF8 string exists on that boundary.
@@ -941,9 +940,9 @@ class Brain
         # (^~this~$) to enforce boundaries.
         # Note that this isn't perfect, still, as we still have to rely on spaces as word
         # separators in UTF8 strings - unspaced comma separations would fail (foo,bar vs foo bar)
-        if match.index != 0 or j > 0
+        if match.index != 0 or pidx > 0
             p = "(?:\\s|\\b)+" + p
-        if (match.index + 9) < regexp.length or j < len - 1
+        if (match.index + 9) < regexp.length or pidx < regexp.length - 1
             p += "(?:\\s|\\b)+"
         opts.push(p)
 

--- a/test/test-promises-replies.coffee
+++ b/test/test-promises-replies.coffee
@@ -48,6 +48,7 @@ exports.test_previous = (test) ->
   .then -> bot.replyPromisified("2", "Yes!")
   .then -> bot.replyPromisified("Ask me a question", "How many arms do I have?")
   .then -> bot.replyPromisified("lol", "That isn't a number.")
+  .catch (err) -> test.ok(false, err.stack)
   .then -> test.done()
 
 exports.test_random = (test) ->

--- a/test/test-unicode.coffee
+++ b/test/test-unicode.coffee
@@ -89,3 +89,22 @@ exports.test_punctuation = (test) ->
   bot.reply("Hello bot", "Hello human!")
   bot.reply("Hello, bot!", "ERR: No Reply Matched")
   test.done()
+
+exports.test_alternatives_and_optionals = (test) ->
+  bot = new TestCase(test, """
+    
+    + [*] to your [*]
+    - Wild.
+
+    + [*] 아침 [*]
+    - UTF8 Wild.
+  """, {"utf8": true})
+
+  bot.reply("foo to your bar", "Wild.")
+  bot.reply("foo to your", "Wild.")
+  bot.reply("to your bar", "Wild.")
+  bot.reply("to your", "Wild.")
+  bot.reply("아침", "UTF8 Wild.")
+  bot.reply("아침 선생님.", "UTF8 Wild.")
+  bot.reply("좋은 아침", "UTF8 Wild.")
+  test.done()


### PR DESCRIPTION
Modify how optional strings are treated in a way that's friendlier to UTF8 strings.