### PR TITLE
Hooks through redirect

### DIFF
--- a/src/brain.coffee
+++ b/src/brain.coffee
@@ -405,19 +405,17 @@ class Brain
       else
         output = @master.errors.objectNotFound
 
-      # if we get a promise back and we are not in the async mode,
-      # leave an error message to suggest using an async version of rs
-      # otherwise, keep promises tucked into a list where we can check on
-      # them later
-      if utils.isAPromise(output)
-        if async
-          promises.push
-            promise: output
-            text: k
-          continue
-        else
-          output = "[ERR: Using async routine with reply: use replyAsync instead]"
-
+      if async
+        # If our output isn't a promise, wrap it
+        if not utils.isAPromise(output)
+          output = new RSVP.Promise((resolve)->resolve(output))
+        promises.push
+          promise: output
+          text: k
+        continue
+      else if utils.isAPromise(output)
+        output = "[ERR: Using async routine with reply: use replyAsync instead]"
+    
       reply = @._replaceCallTags(k, output, reply)
 
     if not async

--- a/src/lang/javascript.coffee
+++ b/src/lang/javascript.coffee
@@ -43,11 +43,11 @@ class JSObjectHandler
         @_master.warn "Error evaluating JavaScript object: " + e.message
 
   ##
-  # string call (RiveScript rs, string name, string[] fields)
+  # string call (RiveScript rs, string name, string[] fields, object hooks)
   #
   # Called by the RiveScript object to execute JavaScript code.
   ##
-  call: (rs, name, fields, scope) ->
+  call: (rs, name, fields, scope, hooks) ->
     # We have it?
     if not @_objects[name]
       return @_master.errors.objectNotFound
@@ -56,7 +56,7 @@ class JSObjectHandler
     func = @_objects[name]
     reply = ""
     try
-      reply = func.call(scope, rs, fields)
+      reply = func.call(scope, rs, fields, hooks)
     catch e
       reply = "[ERR: Error when executing JavaScript object: #{e.message}]"
 

--- a/test/test-base.coffee
+++ b/test/test-base.coffee
@@ -34,7 +34,7 @@ class TestCase
     ##
     reply: (message, expected) ->
         reply = @rs.reply(this.username, message)
-        @test.equal(reply, expected);
+        @test.equal(reply, expected, "Failed responding to '" + message + "'")
 
     ##
     # Random reply assertion: check if the answer is in a set of acceptable

--- a/test/test-promises-base.coffee
+++ b/test/test-promises-base.coffee
@@ -33,10 +33,15 @@ class TestCase
     #
     # @param message: The user's input message.
     # @param expected: The expected response.
+    # @param opts: [scope=null, skipBegin=false, hooks={}]
+    #
     ##
-    replyPromisified: (message, expected) ->
-      @rs.replyPromisified(@username, message).then (reply) =>
-         @test.equal(reply, expected)
+    replyPromisified: (message, expected, opts) ->
+      opts = opts ? []
+      args = [@username, message, opts[0] ? null, opts[1] ? false, opts[2] ? {}]
+      @rs.replyPromisified.apply(@rs, args).then (reply) =>
+      # @rs.replyPromisified(@username, message).then (reply) =>
+         @test.equal(reply, expected, "Failed responding to '" + message + "'")
          reply
 
     ##

--- a/test/test-promises-objects.coffee
+++ b/test/test-promises-objects.coffee
@@ -156,7 +156,7 @@ exports.test_objects_in_conditions = (test) ->
   # First, make sure the sync object works.
   bot.replyPromisified("call sync 1", "Result: true")
   .then -> bot.replyPromisified("call sync 0", "Result: false")
-  .then -> bot.replyPromisified("call async 1", "Result: [ERR: Using async routine with reply: use replyAsync instead]")
+  .then -> bot.replyPromisified("call async 1", "Result: true")
 
   # Test the synchronous object in a conditional.
   .then -> bot.replyPromisified("test sync 1", "True.")
@@ -370,7 +370,7 @@ exports.test_use_reply_with_async_subroutines = (test) ->
     )
   )
 
-  bot.replyPromisified("my name is Rive", "hello there [ERR: Using async routine with reply: use replyAsync instead]")
+  bot.replyPromisified("my name is Rive", "hello there stranger")
   .then -> test.done()
 
 exports.test_errors_in_async_subroutines_with_callbacks = (test) ->


### PR DESCRIPTION
The new hooks system was failing when a macro triggered a secondary reply.  Hooks are applied on a per-reply basis, and there was no way to re-apply them to the inner reply.  To fix this, we now pass hooks around through macro calls, giving macros a chance to re-use the hooks as desired.

In order to solve the specific use case that prompted this change, the way async macros were handled was also changed.  Now, for promisified replies, all macros CAN be async, and will work even if they're not.