### PR TITLE
Array optimization

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivescript",
-  "version": "1.17.8",
+  "version": "1.17.9",
   "description": "RiveScript is a scripting language for chatterbots, making it easy to write trigger/response pairs for building up a bot's intelligence.",
   "keywords": [
     "bot",

--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -107,9 +107,16 @@ class Parser
       space: " "
 
     # Go through the lines of code.
+    # Note that we'll use a "while" and a manual iterator instead of a loop
+    #   so we can jump ahead if necessary.  Regular coffeescript for loops 
+    #   prevent that behavior.
     lines = code.split "\n"
-    for line, lp in lines
-      lineno = lp + 1
+    lineno = 0
+
+    while lineno < lines.length
+      lineno = lineno + 1
+      lp = lineno - 1
+      line = lines[lp]
 
       # Strip the line.
       line = utils.strip line
@@ -316,6 +323,9 @@ class Parser
               fields = fields.filter (val)-> val != ''
 
               ast.begin.array[name] = fields
+                
+              # Skip ahead to the end of the array declaration found in our lookahead
+              lineno = lineno + li # li should be the last index in the lookahead loop
 
             when "sub"
               # Substitutions


### PR DESCRIPTION
A production bot with massive arrays was taking several seconds to compile.  This was because of an unoptimized behavior in the coffeescript parser - each line of a script aggressively looks ahead to the end of a construct, but never recognizes that the end is known and instead re-processes each previously analyzed line.  That means a 4000-line array (which the bot had) had to perform 4000! (factorial) operations to complete.

This new strategy persists the identity of the last element of the array and fast-forwards the parser's pointer to it, saving a great deal of time and effort.