### PR TITLE
Fix bug around invoking multiple macros in single response

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivescript",
-  "version": "1.17.10",
+  "version": "1.17.11",
   "description": "RiveScript is a scripting language for chatterbots, making it easy to write trigger/response pairs for building up a bot's intelligence.",
   "keywords": [
     "bot",

--- a/src/brain.coffee
+++ b/src/brain.coffee
@@ -356,18 +356,13 @@ class Brain
     argsRe = /«__call_arg__»([\s\S]*?)«\/__call_arg__»/ig
 
     giveup = 0
-    matches = {}
+    matches = []
     promises = []
 
-    while true
+    while match = callRe.exec(reply)
       giveup++
       if giveup >= 50
         @warn "Infinite loop looking for call tag!"
-        break
-
-      match = callRe.exec(reply)
-
-      if not match
         break
 
       text = utils.trim(match[1])
@@ -379,61 +374,62 @@ class Brain
       args = []
 
       # get arguments
-      while true
-        m = argsRe.exec(text)
-        if not m
-          break
+      while m = argsRe.exec(text)
         args.push(m[1])
 
-
-      matches[match[1]] =
+      matches.push
         text: text
         obj: subroutineName
         args: args
+        start: match.index
+        length: match[0].length
 
     # go through all the object calls and run functions
-    for k,data of matches
+    for data in matches
       output = ""
       if @master._objlangs[data.obj]
         # We do. Do we have a handler for it?
         lang = @master._objlangs[data.obj]
         if @master._handlers[lang]
           # We do.
-          output = @master._handlers[lang].call(@master, data.obj, data.args, scope, hooks)
+          data.output = @master._handlers[lang].call(@master, data.obj, data.args, scope, hooks)
         else
-          output = "[ERR: No Object Handler]"
+          data.output = "[ERR: No Object Handler]"
       else
-        output = @master.errors.objectNotFound
+        data.output = @master.errors.objectNotFound
 
+      # if we get a promise back and we are not in the async mode,
+      # leave an error message to suggest using an async version of rs
+      # otherwise, keep promises tucked into a list where we can check on
+      # them later
       if async
-        # If our output isn't a promise, wrap it
-        if not utils.isAPromise(output)
-          output = new RSVP.Promise((resolve)->resolve(output))
         promises.push
-          promise: output
-          text: k
+          promise: if utils.isAPromise(data.output) then data.output else q(data.output)
+          data: data
         continue
-      else if utils.isAPromise(output)
-        output = "[ERR: Using async routine with reply: use replyAsync instead]"
-    
-      reply = @._replaceCallTags(k, output, reply)
+      else if utils.isAPromise(data.output)
+        data.output = "[ERR: Using async routine with reply: use replyAsync instead]"
 
     if not async
+      # cycle through backwards so indexes in replace command stay the same
+      for data in matches by -1
+          reply = @._replaceCallTags(data, reply)
       return reply
     else
       # wait for all the promises to be resolved and
       # return a resulting promise with the final reply
       return new RSVP.Promise (resolve, reject) =>
         RSVP.all(p.promise for p in promises).then (results) =>
-          for i in [0...results.length]
-            reply = @_replaceCallTags(promises[i].text, results[i], reply)
+          for promise, i in promises by -1
+            promise.data.output = results[i]
+            reply = @_replaceCallTags(promise.data, reply)
 
           resolve(reply)
         .catch (reason) =>
           reject(reason)
 
-  _replaceCallTags: (callSignature, callResult, reply) ->
-    return reply.replace(new RegExp("<call>" + utils.quotemeta(callSignature) + "</call>", "i"), callResult)
+  _replaceCallTags: (data, reply) ->
+    return reply.slice(0, data.start) + data.output + reply.slice(data.start + data.length)
 
   _parseCallArgsString: (args) ->
     # turn args string into a list of arguments

--- a/test/test-promises-objects.coffee
+++ b/test/test-promises-objects.coffee
@@ -434,6 +434,23 @@ exports.test_async_and_sync_subroutines_together = (test) ->
     test.equal(reply, "hello there stranger!")
     test.done()
 
+exports.test_multiple_calls = (test) ->
+  bot = new TestCase(test, """
+    > object hello javascript
+      return Math.random()
+    < object
+    + hello
+    - <call>hello</call> <call>hello</call>
+  """)
+
+  src = bot.rs.replyAsync(bot.username, "hello").then (reply) ->
+      parts = reply.split(' ')
+      test.ok(parts.length == 2)
+      test.ok(Boolean(parseFloat(parts[0])), parts[0])
+      test.ok(Boolean(parseFloat(parts[1])), parts[1])
+      test.ok(parts[0] != parts[1])
+      test.done()
+
 exports.test_stringify_with_objects = (test) ->
   bot = new TestCase(test, """
     > object hello javascript


### PR DESCRIPTION
This PR addresses the fact that invoking a script like: 

```
> object hello javascript
  return Math.random()
< object

+ hello
- <call>hello</call> <call>hello</call>
```

Would result in the bot only executing the first invocation: 

![image](https://user-images.githubusercontent.com/449652/27975204-46619c2c-632f-11e7-856d-c9262f2b0b69.png)


