### PR TITLE
Added functionality for isolating raw strings in rivescript

### DIFF
--- a/src/brain.coffee
+++ b/src/brain.coffee
@@ -1021,6 +1021,7 @@ class Brain
   # a separate subroutine (refer to `processCallTags` for more info)
   ##
   processTagsPromisified: (user, msg, reply, st, bst, step, scope, hooks) ->
+    {replacements: replacements, result: reply} = utils.extractRaw(reply)
     # Prepare the stars and botstars.
     stars = [""]
     stars.push.apply(stars, st)
@@ -1240,7 +1241,8 @@ class Brain
         @say "Inline redirection to: #{target}"
         @_getReplyWithHooks(user, target, "normal", step+1, scope, hooks).then (subreply) =>
           reply = reply.replace(new RegExp("\\{@" + utils.quotemeta(match[1]) + "\\}", "i"), subreply)
-    , q(reply))
+    , q(reply)).then =>
+      utils.restoreRaw(reply, replacements)
 
   ##
   # string processTags (string user, string msg, string reply, string[] stars,

--- a/src/utils.coffee
+++ b/src/utils.coffee
@@ -10,7 +10,7 @@
 ##
 
 exports.RAW_DELIMITER = '##'
-exports.RAW_START = parseInt('EA00', 16) # Arbitrarly private-use unicode character
+exports.RAW_START = parseInt('FA000', 16) # Arbitrarly private-use unicode character
 
 ##
 # string strip (string)
@@ -182,16 +182,16 @@ exports.nIndexOf = (string, match, index) ->
 #
 # Usage:
 # string = "Do you want to ##<get foo>##?"
-# return = {result: "Do you want to !?", replacements: {!: "<get foo>"}}
+# return = {result: "Do you want to !?", replacements: {!: "##<get foo>##"}}
 #
 # Summary: Strips chunks flagged as raw from string
 ##
 exports.extractRaw = (string) ->
-  re = new RegExp(exports.RAW_DELIMITER + '(.*?)' + exports.RAW_DELIMITER, 'g')
+  re = new RegExp('(' + exports.RAW_DELIMITER + '.*?' + exports.RAW_DELIMITER + ')', 'g')
   response = {replacements: {}, result: ''}
   currKey = exports.RAW_START
   response.result = string.replace(re, ((match, raw, pos) ->
-    replacement = String.fromCharCode(currKey)
+    replacement = String.fromCodePoint(currKey)
     response.replacements[replacement] = raw
     currKey += 1
     replacement
@@ -215,3 +215,20 @@ exports.restoreRaw = (string, replacements) ->
   for placeholder, replacement of replacements
     string = string.replace(placeholder, replacement)
   string
+
+##
+# string cleanupRaw (string)
+#
+# Clears any raw delimiters remaining in a string
+#
+# Usage:
+# string = "Do you want to ! ##<get foo>##?"
+# return = "Do you want to <get foo>?"
+#
+# Summary: Removes characters left over from raw processing
+##
+exports.cleanupRaw = (string) ->
+  rangeStart = exports.RAW_START.toString(16)
+  rangeEnd = (exports.RAW_START + 100).toString(16)
+  re = new RegExp('(?:' + exports.RAW_DELIMITER + ')', 'g')
+  return string.replace(re, '')

--- a/src/utils.coffee
+++ b/src/utils.coffee
@@ -9,8 +9,9 @@
 # Miscellaneous utility functions.
 ##
 
-exports.RAW_DELIMITER = '##'
-exports.RAW_START = parseInt('FA000', 16) # Arbitrarly private-use unicode character
+exports.RAW_DELIMITER_START = '<raw>'
+exports.RAW_DELIMITER_END   = '</raw>'
+exports.RAW_PLACEHOLDER_START = parseInt('FA000', 16) # Arbitrarly private-use unicode character
 
 ##
 # string strip (string)
@@ -181,15 +182,15 @@ exports.nIndexOf = (string, match, index) ->
 # Pass string and replacements back to restoreRaw to reverse.
 #
 # Usage:
-# string = "Do you want to ##<get foo>##?"
-# return = {result: "Do you want to !?", replacements: {!: "##<get foo>##"}}
+# string = "Do you want to <raw><get foo></raw>?"
+# return = {result: "Do you want to !?", replacements: {!: "<raw><get foo></raw>"}}
 #
 # Summary: Strips chunks flagged as raw from string
 ##
 exports.extractRaw = (string) ->
-  re = new RegExp('(' + exports.RAW_DELIMITER + '.*?' + exports.RAW_DELIMITER + ')', 'g')
+  re = new RegExp('(' + exports.RAW_DELIMITER_START + '.*?' + exports.RAW_DELIMITER_END + ')', 'g')
   response = {replacements: {}, result: ''}
-  currKey = exports.RAW_START
+  currKey = exports.RAW_PLACEHOLDER_START
   response.result = string.replace(re, ((match, raw, pos) ->
     replacement = String.fromCodePoint(currKey)
     response.replacements[replacement] = raw
@@ -207,7 +208,7 @@ exports.extractRaw = (string) ->
 # Usage:
 # string = "Do you want to !?"
 # replacements = {!: "<get foo>"}
-# return = "Do you want to ##<get foo>##?"
+# return = "Do you want to <raw><get foo></raw>?"
 #
 # Summary: Restores strings stripped via extractRaw
 ##
@@ -222,13 +223,11 @@ exports.restoreRaw = (string, replacements) ->
 # Clears any raw delimiters remaining in a string
 #
 # Usage:
-# string = "Do you want to ! ##<get foo>##?"
+# string = "Do you want to <raw><get foo></raw>?"
 # return = "Do you want to <get foo>?"
 #
 # Summary: Removes characters left over from raw processing
 ##
 exports.cleanupRaw = (string) ->
-  rangeStart = exports.RAW_START.toString(16)
-  rangeEnd = (exports.RAW_START + 100).toString(16)
-  re = new RegExp('(?:' + exports.RAW_DELIMITER + ')', 'g')
+  re = new RegExp('(?:' + exports.RAW_DELIMITER_START + ')|(?:' + exports.RAW_DELIMITER_END + ')', 'g')
   return string.replace(re, '')

--- a/src/utils.coffee
+++ b/src/utils.coffee
@@ -9,6 +9,9 @@
 # Miscellaneous utility functions.
 ##
 
+exports.RAW_DELIMITER = '##'
+exports.RAW_START = parseInt('EA00', 16) # Arbitrarly private-use unicode character
+
 ##
 # string strip (string)
 #
@@ -169,4 +172,46 @@ exports.isAPromise = (obj) ->
 # Summary: It will look for a second space in the string
 ##
 exports.nIndexOf = (string, match, index) ->
-   return string.split(match, index).join(match).length
+  return string.split(match, index).join(match).length
+
+##
+# string extractRaw (string)
+#
+# Isolates strings identified as "raw" and replaces them with temporary placeholders.
+# Pass string and replacements back to restoreRaw to reverse.
+#
+# Usage:
+# string = "Do you want to ##<get foo>##?"
+# return = {result: "Do you want to !?", replacements: {!: "<get foo>"}}
+#
+# Summary: Strips chunks flagged as raw from string
+##
+exports.extractRaw = (string) ->
+  re = new RegExp(exports.RAW_DELIMITER + '(.*?)' + exports.RAW_DELIMITER, 'g')
+  response = {replacements: {}, result: ''}
+  currKey = exports.RAW_START
+  response.result = string.replace(re, ((match, raw, pos) ->
+    replacement = String.fromCharCode(currKey)
+    response.replacements[replacement] = raw
+    currKey += 1
+    replacement
+  ))
+  response
+
+
+##
+# string restoreRaw (string, object replacements)
+#
+# Restores raw strings previously extracted via extractRaw
+#
+# Usage:
+# string = "Do you want to !?"
+# replacements = {!: "<get foo>"}
+# return = "Do you want to ##<get foo>##?"
+#
+# Summary: Restores strings stripped via extractRaw
+##
+exports.restoreRaw = (string, replacements) ->
+  for placeholder, replacement of replacements
+    string = string.replace(placeholder, replacement)
+  string

--- a/test/test-promises-replies.coffee
+++ b/test/test-promises-replies.coffee
@@ -247,20 +247,20 @@ exports.test_raw = (test) ->
     < object
 
     + rawget
-    - OK ##<get foo>## DONE
+    - OK <raw><get foo></raw> DONE
     
     + rawtopic
-    - OK ##{topic=foo}## DONE
+    - OK <raw>{topic=foo}</raw> DONE
 
     + rawcall
-    - OK ##<call>test</call>## DONE
+    - OK <raw><call>test</call></raw> DONE
     
     + multiraw
-    - ##{@one}## ...OK... ##^two()## ...DONE? ##${{Three}}## !
+    - <raw><call>test</call></raw> <call>test</call> <raw>^two()</raw> ...DONE? <raw>{@ok}</raw>!
   ''')
   bot.replyPromisified('rawget', 'OK <get foo> DONE')
   .then -> bot.replyPromisified('rawtopic', 'OK {topic=foo} DONE')
   .then -> bot.replyPromisified('rawcall', 'OK <call>test</call> DONE')
-  .then -> bot.replyPromisified('multiraw', '{@one} ...OK... ^two() ...DONE? ${{Three}} !')
+  .then -> bot.replyPromisified('multiraw', '<call>test</call> OH NO ^two() ...DONE? {@ok}!')
   .catch (err) -> test.ok(false, err.stack)
   .then -> test.done()

--- a/test/test-promises-replies.coffee
+++ b/test/test-promises-replies.coffee
@@ -242,17 +242,25 @@ exports.test_reply_arrays = (test) ->
 
 exports.test_raw = (test) ->
   bot = new TestCase(test, '''
+    > object test javascript
+    return 'OH NO';
+    < object
+
     + rawget
     - OK ##<get foo>## DONE
     
     + rawtopic
     - OK ##{topic=foo}## DONE
+
+    + rawcall
+    - OK ##<call>test</call>## DONE
     
     + multiraw
     - ##{@one}## ...OK... ##^two()## ...DONE? ##${{Three}}## !
   ''')
   bot.replyPromisified('rawget', 'OK <get foo> DONE')
   .then -> bot.replyPromisified('rawtopic', 'OK {topic=foo} DONE')
+  .then -> bot.replyPromisified('rawcall', 'OK <call>test</call> DONE')
   .then -> bot.replyPromisified('multiraw', '{@one} ...OK... ^two() ...DONE? ${{Three}} !')
   .catch (err) -> test.ok(false, err.stack)
   .then -> test.done()

--- a/test/test-promises-replies.coffee
+++ b/test/test-promises-replies.coffee
@@ -239,3 +239,20 @@ exports.test_reply_arrays = (test) ->
   ])
   .catch (err) -> test.ok(false, err.stack)
   .then -> test.done()
+
+exports.test_raw = (test) ->
+  bot = new TestCase(test, '''
+    + rawget
+    - OK ##<get foo>## DONE
+    
+    + rawtopic
+    - OK ##{topic=foo}## DONE
+    
+    + multiraw
+    - ##{@one}## ...OK... ##^two()## ...DONE? ##${{Three}}## !
+  ''')
+  bot.replyPromisified('rawget', 'OK <get foo> DONE')
+  .then -> bot.replyPromisified('rawtopic', 'OK {topic=foo} DONE')
+  .then -> bot.replyPromisified('multiraw', '{@one} ...OK... ^two() ...DONE? ${{Three}} !')
+  .catch (err) -> test.ok(false, err.stack)
+  .then -> test.done()

--- a/test/test-replies.coffee
+++ b/test/test-replies.coffee
@@ -232,3 +232,27 @@ exports.test_reply_arrays = (test) ->
     "HELLO WORLD", "hello world", "Hello World", "Hello world",
   ])
   test.done()
+
+exports.test_raw = (test) ->
+  bot = new TestCase(test, '''
+    > object test javascript
+    return 'OH NO';
+    < object
+
+    + rawget
+    - OK ##<get foo>## DONE
+    
+    + rawtopic
+    - OK ##{topic=foo}## DONE
+
+    + rawcall
+    - OK ##<call>test</call>## DONE
+    
+    + multiraw
+    - ##{@one}## ...OK... ##^two()## ...DONE? ##${{Three}}## !
+  ''')
+  bot.reply('rawget', 'OK <get foo> DONE')
+  bot.reply('rawtopic', 'OK {topic=foo} DONE')
+  bot.reply('rawcall', 'OK <call>test</call> DONE')
+  bot.reply('multiraw', '{@one} ...OK... ^two() ...DONE? ${{Three}} !')
+  test.done()

--- a/test/test-replies.coffee
+++ b/test/test-replies.coffee
@@ -240,19 +240,19 @@ exports.test_raw = (test) ->
     < object
 
     + rawget
-    - OK ##<get foo>## DONE
+    - OK <raw><get foo></raw> DONE
     
     + rawtopic
-    - OK ##{topic=foo}## DONE
+    - OK <raw>{topic=foo}</raw> DONE
 
     + rawcall
-    - OK ##<call>test</call>## DONE
+    - OK <raw><call>test</call></raw> DONE
     
     + multiraw
-    - ##{@one}## ...OK... ##^two()## ...DONE? ##${{Three}}## !
+    - <raw><call>test</call></raw> <call>test</call> <raw>^two()</raw> ...DONE? <raw>{@ok}</raw>!
   ''')
   bot.reply('rawget', 'OK <get foo> DONE')
   bot.reply('rawtopic', 'OK {topic=foo} DONE')
   bot.reply('rawcall', 'OK <call>test</call> DONE')
-  bot.reply('multiraw', '{@one} ...OK... ^two() ...DONE? ${{Three}} !')
+  bot.reply('multiraw', '<call>test</call> OH NO ^two() ...DONE? {@ok}!')
   test.done()


### PR DESCRIPTION
Add a sequence that allows sections of rivescript to be identified as "raw text", allowing the rivescript inside to be passed through unprocessed.

This is to allow downstream tools that allow re-processing of rivescript (broadcasts, etc.) to be given code instead of the results of the code.

Ex:

```
+ test
- <raw><call>stuff</call></raw> foo <raw><get bar></raw> baz 
// says "<call>stuff</call> foo <get bar> baz
```