### PR TITLE
Fixed get recursion

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivescript",
-  "version": "1.20.0",
+  "version": "1.20.1",
   "description": "RiveScript is a scripting language for chatterbots, making it easy to write trigger/response pairs for building up a bot's intelligence.",
   "keywords": [
     "bot",

--- a/src/brain.coffee
+++ b/src/brain.coffee
@@ -1208,6 +1208,10 @@ class Brain
             @master.setUservar(user, name, result)
       else if tag is "get"
         insert = @master.getUservar(user, data)
+        # Sanity check for infinite loop
+        if String(insert).match(new RegExp('\<get\\s+' + data + '\>'))
+          @warn "Potential infinite loop with data in GET trying to GET itself"
+          insert = ""
       else
         # Unrecognized tag, preserve it
         insert = "\x00#{match}\x01"

--- a/src/brain.coffee
+++ b/src/brain.coffee
@@ -1139,7 +1139,15 @@ class Brain
     reply = reply.replace(/<call>/ig, "«__call__»")
     reply = reply.replace(/<\/call>/ig, "«/__call__»")
 
+    giveup = 0
     while true
+      giveup++
+      # We're pretty loose with this cutoff since there are legitimate reasons for this loop to go on a long time.
+      # However, there's already one exploitable recursion hole found (see the <get> fix below), so this large cap is
+      # in place in order to prevent similar unknown issues from ocurring
+      if giveup > 1000
+        @warn "Infinite loop processing inner tags"
+        break
       # This regexp will match a <tag> which contains no other tag inside it,
       # i.e. in the case of <set a=<get b>> it will match <get b> but not the
       # <set> tag, on the first pass. The second pass will get the <set> tag,

--- a/test/test-promises-replies.coffee
+++ b/test/test-promises-replies.coffee
@@ -264,3 +264,20 @@ exports.test_raw = (test) ->
   .then -> bot.replyPromisified('multiraw', '<call>test</call> OH NO ^two() ...DONE? {@ok}!')
   .catch (err) -> test.ok(false, err.stack)
   .then -> test.done()
+
+exports.test_get_recursion = (test) ->
+  bot = new TestCase(test, '''
+    > object set_recurse_var javascript
+      rs.setUservar(rs.currentUser(), 'next', '<get next>');
+    < object
+    
+    + init
+    - <call>set_recurse_var</call> Ready
+    
+    + go
+    - Foo <get next> Bar
+  ''')
+  bot.replyPromisified('init', ' Ready')
+  .then -> bot.replyPromisified('go', 'Foo  Bar')
+  .catch (err) -> test.ok(false, err.stack)
+  .then -> test.done()


### PR DESCRIPTION
It was previously possible to create infinite recursion using a macro's `rs.setUservar` command to create a variable that contained `<get $self>`.  This fixes that limited exploitation window.