### PR TITLE
Remove the ability for multiple redirects to exist in a single line

### DIFF
--- a/shell.coffee
+++ b/shell.coffee
@@ -105,6 +105,10 @@ rl.on "line", (cmd) ->
     console.log(eval(cmd.replace("/log ", "")))
   else if cmd is "/quit"
     process.exit 0
+  else if cmd.indexOf("/async ") is 0
+    console.log "(replying in promise chain)"
+    bot.replyPromisified("localuser", cmd.replace("/async ", ""))
+    .then (reply) -> console.log "Bot> #{reply}"
   else
     reply = if (bot and bot.ready) then bot.reply("localuser", cmd) else "ERR: Bot not ready yet"
     console.log "Bot> #{reply}"

--- a/src/brain.coffee
+++ b/src/brain.coffee
@@ -1246,9 +1246,9 @@ class Brain
 
     # Inline redirector
     redirects = reply.match(/\{@([^\}]*?)\}/g)
-    _.reduce( redirects, (promise, redirect) =>
-      promise.then =>
-        match = redirect.match(/\{@([^\}]*?)\}/)
+    if redirects
+      q(reply).then =>
+        match = redirects[0].match(/\{@([^\}]*?)\}/)
         target = utils.strip match[1]
 
         # Resolve any *synchronous* <call> tags right now before redirecting.
@@ -1257,8 +1257,8 @@ class Brain
         @say "Inline redirection to: #{target}"
         @_getReplyWithHooks(user, target, "normal", step+1, scope, hooks).then (subreply) =>
           reply = reply.replace(new RegExp("\\{@" + utils.quotemeta(match[1]) + "\\}", "i"), subreply)
-    , q(reply)).then =>
-      utils.restoreRaw(reply, replacements)
+      .then =>
+        utils.restoreRaw(reply, replacements)
 
   ##
   # string processTags (string user, string msg, string reply, string[] stars,
@@ -1480,13 +1480,7 @@ class Brain
 
     # Inline redirector
     match = reply.match(/\{@([^\}]*?)\}/)
-    giveup = 0
-    while match
-      giveup++
-      if giveup >= 50
-        @warn "Infinite loop looking for redirect tag!"
-        break
-
+    if match
       target = utils.strip match[1]
 
       # Resolve any *synchronous* <call> tags right now before redirecting.
@@ -1495,7 +1489,6 @@ class Brain
       @say "Inline redirection to: #{target}"
       subreply = @_getReply(user, target, "normal", step+1, scope)
       reply = reply.replace(new RegExp("\\{@" + utils.quotemeta(match[1]) + "\\}", "i"), subreply)
-      match = reply.match(/\{@([^\}]*?)\}/)
 
     reply = utils.restoreRaw(reply, replacements)
     return reply


### PR DESCRIPTION
Before this PR, rivescript would honor multiple inline redirects in a single line:

```
+ *
- {@test1}{@test2}
```

However, actually communicating with the above bot bypasses all infinite loop protections currently available.  Since there doesn't appear to be a) a way for the above to ever work, and b) a reason to ever do the above, this PR removes such abilities, and will only honor the first redirect given.

Note that this does **not** prevent the ability to chain redirects.  The following still works:

```
+ a
- {@b}

+ b
- {@c}

+ c
- OK

+ * 
- {@a}
```