### PR TITLE
Detect and honor recursion errors in multiple redirects

### DIFF
--- a/shell.coffee
+++ b/shell.coffee
@@ -105,6 +105,10 @@ rl.on "line", (cmd) ->
     console.log(eval(cmd.replace("/log ", "")))
   else if cmd is "/quit"
     process.exit 0
+  else if cmd.indexOf("/async ") is 0
+    console.log "(replying in promise chain)"
+    bot.replyPromisified("localuser", cmd.replace("/async ", ""))
+    .then (reply) -> console.log "Bot> #{reply}"
   else
     reply = if (bot and bot.ready) then bot.reply("localuser", cmd) else "ERR: Bot not ready yet"
     console.log "Bot> #{reply}"

--- a/test/test-promises-replies.coffee
+++ b/test/test-promises-replies.coffee
@@ -278,6 +278,15 @@ exports.test_get_recursion = (test) ->
     - Foo <get next> Bar
   ''')
   bot.replyPromisified('init', ' Ready')
-  .then -> bot.replyPromisified('go', 'Foo  Bar')
+  .then -> bot.replyPromisified('go', "Foo #{bot.rs.errors.recursiveVar} Bar")
+  .catch (err) -> test.ok(false, err.stack)
+  .then -> test.done()
+
+exports.test_replace_recursion = (test) ->
+  bot = new TestCase(test, '''
+    + *
+    - {@a}{@b}
+  ''')
+  bot.replyPromisified('go', "#{bot.rs.errors.deepRecursion}")
   .catch (err) -> test.ok(false, err.stack)
   .then -> test.done()

--- a/test/test-replies.coffee
+++ b/test/test-replies.coffee
@@ -256,3 +256,11 @@ exports.test_raw = (test) ->
   bot.reply('rawcall', 'OK <call>test</call> DONE')
   bot.reply('multiraw', '<call>test</call> OH NO ^two() ...DONE? {@ok}!')
   test.done()
+
+exports.test_replace_recursion = (test) ->
+  bot = new TestCase(test, '''
+    + *
+    - {@a}{@b}
+  ''')
+  bot.reply('go', "#{bot.rs.errors.deepRecursion}")
+  test.done()


### PR DESCRIPTION
Rivescript allows multiple redirects in a single line

```
+ test 1
- A

+ test 2
- B

+ *
# yields AB
- {@test1}{@test2}
```

However, if more than one of those redirects triggers an infinite loop, it causes a chain that cripples our existing loop protections.  For example, if neither explicit trigger above exists, and if our recursion error message is simply "R" and happens after 2 recursions, Rive would process the above like:

```
{@test1}{@test2} (depth 0)
  {@test1'}{@test2'}{@test2} (depth 1)
    R{@test2'}{@test2} (depth 2)
    RR{@test2} (depth 2)
RR{@test2} (depth 0)
  RR{@test1'}{@test2'} (depth 1)
    RRR{@test2'} (depth 2)
    RRRR (depth 2)
RRRR (depth 0)
```
So the process goes for `{redirects}^{maxdepth}` iterations, with a cap of `50^50` given existing protections.  However, even if you just have 2 infinite loop redirects, that's 2^50, or 1,125,899,907,000,000 iterations.  Whoops.

This PR short-circuits the process by killing a response as soon as we see a single maxdepth error.  It turns the above example into:

```
{@test1}{@test2} (depth 0)
  {@test1'}{@test2'}{@test2} (depth 1)
    R{@test2'}{@test2} (depth 2)
R
```

Meaning maxDepth should be honored as intended.  The only side effect is that it changes the way loops normally work, which is to chain a bunch of errors together (RRRR in the above becomes R), but I think that's fine.

Note that this does **not** prevent the ability to chain redirects.  The following still works:

```
+ a
- {@b}

+ b
- {@c}

+ c
- OK

+ * 
- {@a}
```