### PR TITLE
Feat: Force first response

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivescript",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "description": "RiveScript is a scripting language for chatterbots, making it easy to write trigger/response pairs for building up a bot's intelligence.",
   "keywords": [
     "bot",

--- a/src/brain.coffee
+++ b/src/brain.coffee
@@ -1107,7 +1107,8 @@ class Brain
       else
         random = text.split(" ")
 
-      output = random[ parseInt(Math.random() * random.length) ]
+      choice = if @master._forceFirst then 0 else parseInt(Math.random() * random.length)
+      output = random[choice] 
 
       reply = reply.replace(new RegExp("\\{random\\}" + utils.quotemeta(text) + "\\{\\/random\\}", "ig")
         output)
@@ -1361,7 +1362,8 @@ class Brain
       else
         random = text.split(" ")
 
-      output = random[ parseInt(Math.random() * random.length) ]
+      choice = if @master._forceFirst then 0 else parseInt(Math.random() * random.length)
+      output = random[choice]
 
       reply = reply.replace(new RegExp("\\{random\\}" + utils.quotemeta(text) + "\\{\\/random\\}", "ig")
         output)

--- a/src/brain.coffee
+++ b/src/brain.coffee
@@ -219,7 +219,7 @@ class Brain
                 bucket.push rep
 
             # Get a random reply.
-            choice = parseInt(Math.random() * bucket.length)
+            choice = if @master._forceFirst then 1 else parseInt(Math.random() * bucket.length)
             return bucket[choice]
           else if _.get(matched, 'reply.length', 0) is 0
             return @master.errors.replyNotFound
@@ -791,7 +791,7 @@ class Brain
             bucket.push rep
 
         # Get a random reply.
-        choice = parseInt(Math.random() * bucket.length)
+        choice = if @master._forceFirst then 1 else parseInt(Math.random() * bucket.length)
         reply  = bucket[choice]
         break
 

--- a/src/rivescript.coffee
+++ b/src/rivescript.coffee
@@ -41,18 +41,19 @@ readDir = require("fs-readdir-recursive")
 # following keys:
 #
 # ```
-# * bool debug:     Debug mode               (default false)
-# * int  depth:     Recursion depth limit    (default 50)
-# * bool strict:    Strict mode              (default true)
-# * bool utf8:      Enable UTF-8 mode        (default false, see below)
-# * bool forceCase: Force-lowercase triggers (default false, see below)
-# * func onDebug:   Set a custom handler to catch debug log messages (default null)
-# * func onStats:   Set a custom handler to get statistics when available (default null)
-# * obj  errors:    Customize certain error messages (see below)
-# * str  concat:    Globally replace the default concatenation mode when parsing
-#                   RiveScript source files (default `null`. be careful when
-#                   setting this option if using somebody else's RiveScript
-#                   personality; see below)
+# * bool debug:      Debug mode               (default false)
+# * int  depth:      Recursion depth limit    (default 50)
+# * bool strict:     Strict mode              (default true)
+# * bool utf8:       Enable UTF-8 mode        (default false, see below)
+# * bool forceCase:  Force-lowercase triggers (default false, see below)
+# * bool forceFirst: Force selection of first result (default false, see below)
+# * func onDebug:    Set a custom handler to catch debug log messages (default null)
+# * func onStats:    Set a custom handler to get statistics when available (default null)
+# * obj  errors:     Customize certain error messages (see below)
+# * str  concat:     Globally replace the default concatenation mode when parsing
+#                    RiveScript source files (default `null`. be careful when
+#                    setting this option if using somebody else's RiveScript
+#                    personality; see below)
 # ```
 #
 # ## UTF-8 Mode
@@ -85,6 +86,21 @@ readDir = require("fs-readdir-recursive")
 # in triggers, see [case folding in Unicode](https://www.w3.org/International/wiki/Case_folding).
 # If you need to support Unicode symbols in triggers this may cause problems with
 # certain symbols when made lowercase.
+#
+# ## Force First
+#
+# In some execution contexts (like running deterministic tests against the bot),
+# you want to avoid unpredictable results.  In these cases you can configure the
+# bot to always only return the first possible result from a set, so
+#
+# ```
+# + rand
+# - 1
+# - 2
+# - 3
+# ```
+#
+# will only ever return 1.
 #
 # ## Global Concat Mode
 #
@@ -184,14 +200,15 @@ class RiveScript
       opts = {}
 
     # Default parameters
-    @_debug     = if opts.debug then opts.debug else false
-    @_strict    = if opts.strict then opts.strict else true
-    @_depth     = if opts.depth then parseInt(opts.depth) else 50
-    @_utf8      = if opts.utf8 then opts.utf8 else false
-    @_forceCase = if opts.forceCase then opts.forceCase else false
-    @_onDebug   = if opts.onDebug then opts.onDebug else null
-    @_onStats   = if opts.onStats then opts.onStats else null
-    @_concat    = if opts.concat then opts.concat else null
+    @_debug      = if opts.debug then opts.debug else false
+    @_strict     = if opts.strict then opts.strict else true
+    @_depth      = if opts.depth then parseInt(opts.depth) else 50
+    @_utf8       = if opts.utf8 then opts.utf8 else false
+    @_forceCase  = if opts.forceCase then opts.forceCase else false
+    @_forceFirst = if opts.forceFirst then opts.forceFirst else false
+    @_onDebug    = if opts.onDebug then opts.onDebug else null
+    @_onStats    = if opts.onStats then opts.onStats else null
+    @_concat     = if opts.concat then opts.concat else null
     @_historyCount = if opts.historyCount then opts.historyCount else 10
 
     # UTF-8 punctuation, overridable by the user.

--- a/test/test-promises-replies.coffee
+++ b/test/test-promises-replies.coffee
@@ -71,7 +71,6 @@ exports.test_unrandom = (test) ->
   bot = new TestCase(test, """
     + test random response
     - One.
-    - Three.
     - Two.
     - Two.
     - Two.
@@ -80,6 +79,9 @@ exports.test_unrandom = (test) ->
     - Two.
     - Two.
     - Two.
+
+    + test random tag
+    - Pick {random}1|2|2|2|2|2|2|2|2|2|2{/random}
   """, {"forceFirst": true})
   # Yeah, this is ugly and imperfect, but there isn't a good way to test a pool of answers right now.
   bot.replyPromisified("test random response", "One.")
@@ -92,6 +94,16 @@ exports.test_unrandom = (test) ->
   .then -> bot.replyPromisified("test random response", "One.")
   .then -> bot.replyPromisified("test random response", "One.")
   .then -> bot.replyPromisified("test random response", "One.")
+  .then -> bot.replyPromisified("test random tag", "Pick 1")
+  .then -> bot.replyPromisified("test random tag", "Pick 1")
+  .then -> bot.replyPromisified("test random tag", "Pick 1")
+  .then -> bot.replyPromisified("test random tag", "Pick 1")
+  .then -> bot.replyPromisified("test random tag", "Pick 1")
+  .then -> bot.replyPromisified("test random tag", "Pick 1")
+  .then -> bot.replyPromisified("test random tag", "Pick 1")
+  .then -> bot.replyPromisified("test random tag", "Pick 1")
+  .then -> bot.replyPromisified("test random tag", "Pick 1")
+  .then -> bot.replyPromisified("test random tag", "Pick 1")
   .then -> test.done()
 
 exports.test_continuations = (test) ->

--- a/test/test-promises-replies.coffee
+++ b/test/test-promises-replies.coffee
@@ -67,6 +67,33 @@ exports.test_random = (test) ->
   ])
   .then -> test.done()
 
+exports.test_unrandom = (test) ->
+  bot = new TestCase(test, """
+    + test random response
+    - One.
+    - Three.
+    - Two.
+    - Two.
+    - Two.
+    - Two.
+    - Two.
+    - Two.
+    - Two.
+    - Two.
+  """, {"forceFirst": true})
+  # Yeah, this is ugly and imperfect, but there isn't a good way to test a pool of answers right now.
+  bot.replyPromisified("test random response", "One.")
+  .then -> bot.replyPromisified("test random response", "One.")
+  .then -> bot.replyPromisified("test random response", "One.")
+  .then -> bot.replyPromisified("test random response", "One.")
+  .then -> bot.replyPromisified("test random response", "One.")
+  .then -> bot.replyPromisified("test random response", "One.")
+  .then -> bot.replyPromisified("test random response", "One.")
+  .then -> bot.replyPromisified("test random response", "One.")
+  .then -> bot.replyPromisified("test random response", "One.")
+  .then -> bot.replyPromisified("test random response", "One.")
+  .then -> test.done()
+
 exports.test_continuations = (test) ->
   bot = new TestCase(test, """
     + tell me a poem

--- a/test/test-replies.coffee
+++ b/test/test-replies.coffee
@@ -64,6 +64,34 @@ exports.test_random = (test) ->
   ])
   test.done()
 
+exports.test_unrandom = (test) ->
+  bot = new TestCase(test, """
+    + test random response
+    - One.
+    - Two.
+    - Two.
+    - Two.
+    - Two.
+    - Two.
+    - Two.
+    - Two.
+    - Two.
+    - Two.
+  """, {"forceFirst": true})
+  # Yeah, this is ugly and imperfect, but there isn't a good way to test a pool of answers right now.
+  bot.reply("test random response", "One.")
+  bot.reply("test random response", "One.")
+  bot.reply("test random response", "One.")
+  bot.reply("test random response", "One.")
+  bot.reply("test random response", "One.")
+  bot.reply("test random response", "One.")
+  bot.reply("test random response", "One.")
+  bot.reply("test random response", "One.")
+  bot.reply("test random response", "One.")
+  bot.reply("test random response", "One.")
+  bot.reply("test random response", "One.")
+  test.done()
+
 exports.test_continuations = (test) ->
   bot = new TestCase(test, """
     + tell me a poem

--- a/test/test-replies.coffee
+++ b/test/test-replies.coffee
@@ -77,6 +77,9 @@ exports.test_unrandom = (test) ->
     - Two.
     - Two.
     - Two.
+
+    + test random tag
+    - Pick {random}1|2|2|2|2|2|2|2|2|2|2{/random}
   """, {"forceFirst": true})
   # Yeah, this is ugly and imperfect, but there isn't a good way to test a pool of answers right now.
   bot.reply("test random response", "One.")
@@ -89,7 +92,16 @@ exports.test_unrandom = (test) ->
   bot.reply("test random response", "One.")
   bot.reply("test random response", "One.")
   bot.reply("test random response", "One.")
-  bot.reply("test random response", "One.")
+  bot.reply("test random tag", "Pick 1")
+  bot.reply("test random tag", "Pick 1")
+  bot.reply("test random tag", "Pick 1")
+  bot.reply("test random tag", "Pick 1")
+  bot.reply("test random tag", "Pick 1")
+  bot.reply("test random tag", "Pick 1")
+  bot.reply("test random tag", "Pick 1")
+  bot.reply("test random tag", "Pick 1")
+  bot.reply("test random tag", "Pick 1")
+  bot.reply("test random tag", "Pick 1")
   test.done()
 
 exports.test_continuations = (test) ->


### PR DESCRIPTION
Writing a deterministic test framework doesn't work well with random responses.  Internal Rivescript tests handle random responses by knowing the entire pool of contrived responses, like:

assert([reply1, reply2, ..., replyN].indexOf(actualReply) >= 0)

For a real bot with large, complex replies, the above can be onerous, so this PR lets us lock in the first reply to simplify test writing.